### PR TITLE
point submodules to public HTTPS URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "voxel-io"]
 	path = voxelio
-	url = git@github.com:Eisenwave/voxel-io.git
+	url = https://github.com/Eisenwave/voxel-io.git
 [submodule "args"]
 	path = tayweeargs
-	url = git@github.com:Taywee/args.git
+	url = https://github.com/Taywee/args.git
 [submodule "tinyobjloader"]
 	path = tinyobjloader
-	url = git@github.com:tinyobjloader/tinyobjloader.git
+	url = https://github.com/tinyobjloader/tinyobjloader.git


### PR DESCRIPTION
If you point `.gitmodules` to SSH URLs, recursive cloning requires a GitHub account and a SSH key being configured. You can make your repository more accessible to users by using HTTPS URLs instead (implemented by this PR).